### PR TITLE
Add include_directories directive to modified CMakeLists

### DIFF
--- a/create_package_modified/catkin_ws/src/beginner_tutorials/CMakeLists.txt
+++ b/create_package_modified/catkin_ws/src/beginner_tutorials/CMakeLists.txt
@@ -16,5 +16,5 @@ generate_messages(DEPENDENCIES std_msgs)
 catkin_package()
 
 ## Include headers of found catkin packages
-include_directories(include ${catkin_INCLUDE_DIRS})
+include_directories(${catkin_INCLUDE_DIRS})
 # %EndTag(FULLTEXT)%

--- a/create_package_modified/catkin_ws/src/beginner_tutorials/CMakeLists.txt
+++ b/create_package_modified/catkin_ws/src/beginner_tutorials/CMakeLists.txt
@@ -15,4 +15,6 @@ generate_messages(DEPENDENCIES std_msgs)
 ## Declare a catkin package
 catkin_package()
 
+## Include headers of found catkin packages
+include_directories(include ${catkin_INCLUDE_DIRS})
 # %EndTag(FULLTEXT)%


### PR DESCRIPTION
`catkin_create_pkg` generates a CMakeLists that already contains the `include_directories` call. It should be part of this snippet and removed from the snippet "Don't worry about modifying the commented (#) examples, simply add these few lines to the bottom of your CMakeLists.txt: " in [this tutorial](http://wiki.ros.org/roscpp_tutorials/Tutorials/WritingPublisherSubscriber) 