### PR TITLE
Minor edit, "message_generation" instead "genmsg"

### DIFF
--- a/create_package_modified/catkin_ws/src/beginner_tutorials/CMakeLists.txt
+++ b/create_package_modified/catkin_ws/src/beginner_tutorials/CMakeLists.txt
@@ -13,6 +13,14 @@ add_service_files(DIRECTORY srv FILES AddTwoInts.srv)
 generate_messages(DEPENDENCIES std_msgs)
 
 ## Declare a catkin package
-catkin_package()
+catkin_package(
+  INCLUDE_DIRS include
+  LIBRARIES beginner_tutorials
+  CATKIN_DEPENDS message_runtime roscpp rospy std_msgs
+  DEPENDS system_lib
+)
+
+## Specify additional locations of header files
+include_directories(${catkin_INCLUDE_DIRS})
 
 # %EndTag(FULLTEXT)%

--- a/create_package_modified/catkin_ws/src/beginner_tutorials/CMakeLists.txt
+++ b/create_package_modified/catkin_ws/src/beginner_tutorials/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(beginner_tutorials)
 
 ## Find catkin and any catkin packages
-find_package(catkin REQUIRED COMPONENTS roscpp rospy std_msgs genmsg)
+find_package(catkin REQUIRED COMPONENTS roscpp rospy std_msgs message_generation)
 
 ## Declare ROS messages and services
 add_message_files(DIRECTORY msg FILES Num.msg)

--- a/create_package_pubsub/catkin_ws/src/beginner_tutorials/CMakeLists.txt
+++ b/create_package_pubsub/catkin_ws/src/beginner_tutorials/CMakeLists.txt
@@ -13,11 +13,17 @@ add_service_files(FILES AddTwoInts.srv)
 generate_messages(DEPENDENCIES std_msgs)
 
 ## Declare a catkin package
-catkin_package()
+catkin_package(
+  INCLUDE_DIRS include
+  LIBRARIES beginner_tutorials
+  CATKIN_DEPENDS message_runtime roscpp rospy std_msgs
+  DEPENDS system_lib
+)
+
+## Specify additional locations of header files
+include_directories(${catkin_INCLUDE_DIRS})
 
 ## Build talker and listener
-include_directories(include ${catkin_INCLUDE_DIRS})
-
 add_executable(talker src/talker.cpp)
 target_link_libraries(talker ${catkin_LIBRARIES})
 add_dependencies(talker beginner_tutorials_generate_messages_cpp)


### PR DESCRIPTION
Regarding the "message_generation" dependency vs the "genmsg" dependency.

I noticed a minor inconsistency here, compared to what is stated in the previous page: [CreatingMsgAndSrv](https://wiki.ros.org/ROS/Tutorials/CreatingMsgAndSrv). Found about issue [#6](https://github.com/ros/catkin_tutorials/issues/8) and decided to try to contribute a small edit.

I guess I'll include @jack-oquin as he's the one responsible for issue #6..