### PR TITLE
Add additional dependencies for the beginner tutorials

### DIFF
--- a/create_package_generated/catkin_ws/src/beginner_tutorials/package.xml
+++ b/create_package_generated/catkin_ws/src/beginner_tutorials/package.xml
@@ -55,6 +55,13 @@
   <build_depend>roscpp</build_depend>
   <build_depend>rospy</build_depend>
   <build_depend>std_msgs</build_depend>
+  <build_export_depend>roscpp</build_export_depend>
+  <build_export_depend>rospy</build_export_depend>
+  <build_export_depend>std_msgs</build_export_depend>
+  <exec_depend>roscpp</exec_depend>
+  <exec_depend>rospy</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+
   <!-- %EndTag(DEPS)% -->
 
   <!-- %Tag(EXPORT)% -->


### PR DESCRIPTION
When using `catkin_create_pkg` on Melodic, the dependencies contain `buildtool_depend`, `build_depend`, `build_export_depend`, and `exec_depend`.  Update the `DEP` section here to match.