### PR TITLE
The include_directories part is missing is this piece of code.

### DIFF
--- a/create_package_modified/catkin_ws/src/beginner_tutorials/CMakeLists.txt
+++ b/create_package_modified/catkin_ws/src/beginner_tutorials/CMakeLists.txt
@@ -15,4 +15,7 @@ generate_messages(DEPENDENCIES std_msgs)
 ## Declare a catkin package
 catkin_package()
 
+## Build talker and listener
+include_directories(include ${catkin_INCLUDE_DIRS})
+
 # %EndTag(FULLTEXT)%


### PR DESCRIPTION
I saw some students struggling with the C++ tutorials. They created their CMakeLists.txt file by taking this piece of code, together with the pieces following it. In that case, you end up without the include_directories part.